### PR TITLE
add templateId property to content class

### DIFF
--- a/src/SparkPostDotNet/Transmissions/Content.cs
+++ b/src/SparkPostDotNet/Transmissions/Content.cs
@@ -32,5 +32,8 @@
 
         [JsonProperty("inline_images")]
         public IList<Attachment> InlineImages { get; set; }
+
+        [JsonProperty("template_id")]
+        public string TemplateId { get; set; }
     }
 }


### PR DESCRIPTION
Add TempalteId to use it if we already have templates in sparkpost and want to use them
