### PR TITLE
Optional API host URI configuration

### DIFF
--- a/src/SparkPostDotNet/SparkPostClient.cs
+++ b/src/SparkPostDotNet/SparkPostClient.cs
@@ -13,9 +13,11 @@
             this.Options = options.Value;
         }
 
-        protected SparkPostOptions Options { get; set; }
+        private const string DEFAULT_URI = "https://api.sparkpost.com/api/v1/transmissions";
 
-        protected Uri SparkPostUri {  get { return new Uri("https://api.sparkpost.com/api/v1/transmissions"); } }
+        protected SparkPostOptions Options { get; }
+
+        protected Uri SparkPostUri => new Uri(string.IsNullOrEmpty(this.Options.ApiHostUri) ? DEFAULT_URI : this.Options.ApiHostUri);
 
         public async Task CreateTransmission(Transmission transmission)
         {
@@ -30,7 +32,7 @@
                 transmission.Headers.Add("Content-Type", "application/json");
                 httpClient.DefaultRequestHeaders.Add("Authorization", this.Options.ApiKey);
                 var response = await httpClient.PostAsync(this.SparkPostUri, transmission);
-                if(!response.IsSuccessStatusCode)
+                if (!response.IsSuccessStatusCode)
                 {
                     throw new Exception(await response.Content.ReadAsStringAsync());
                 }

--- a/src/SparkPostDotNet/SparkPostOptions.cs
+++ b/src/SparkPostDotNet/SparkPostOptions.cs
@@ -3,5 +3,10 @@
     public class SparkPostOptions
     {
         public string ApiKey { get; set; }
+
+        /// <summary>
+        /// An optional host uri. If none is provided, the default of 'https://api.sparkpost.com/api/v1/transmissions' is used.
+        /// </summary>
+        public string ApiHostUri { get; set; }
     }
 }


### PR DESCRIPTION
Hi, we use your awesome library in a project of ours. It works well and stuff, but we recently stumbled upon an issue where we need to change the API host URL (we started using the enterprise SparkPost solution).
This PR allows the library user to optionally configure said URL through the standard mechanisms.